### PR TITLE
feat: `explode` will only activate Jetpacks by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ The complete feature set includes the following.
 | Unlock all doors              | `/unlock`                       |
 | Lock all gates                | `/lock`                         |
 | Heal self                     | `/heal`                         |
-| Explode all mines             | `/explode`                      |
-| Explode all jetpacks          | `/explode jet`                  |
+| Explode all jetpacks          | `/explode`                      |
+| Explode all landmines         | `/explode mine`                  |
 
 ### Binds
 

--- a/lc-hax/Scripts/Commands/ExplodeCommand.cs
+++ b/lc-hax/Scripts/Commands/ExplodeCommand.cs
@@ -5,13 +5,13 @@ namespace Hax;
 public class ExplodeCommand : ICommand {
     public void Execute(string[] args) {
         if (args.Length is 0) {
-            Object.FindObjectsOfType<Landmine>()
-                  .ForEach(mine => mine.TriggerMine());
-        }
-
-        if (args[0] is "jet") {
             Object.FindObjectsOfType<JetpackItem>()
                   .ForEach(jetpack => jetpack.ExplodeJetpackServerRpc());
+        }
+
+        if (args[0] is "mine") {
+            Object.FindObjectsOfType<Landmine>()
+                  .ForEach(landmine => landmine.TriggerMine());
         }
     }
 }


### PR DESCRIPTION
With the release of `TriggerMod`, the previous implementation of `/explode` has been made obsolete.

However, `TriggerMod` is unable to detonate Jetpacks that have already been equipped as the Jetpack collider disappears. `/explode` will now detonate all Jetpacks, including equipped Jetpacks.

For the purposes of clearing landmines, we can now do `/explode mine` instead.