### PR TITLE
fix: use correct parameter name for `invis` patch

### DIFF
--- a/lc-hax/Scripts/Patches/AntiKickPatch.cs
+++ b/lc-hax/Scripts/Patches/AntiKickPatch.cs
@@ -19,6 +19,7 @@ class AntiKickPatch {
         playerSteamIds[__instance.playerClientId] = SteamClient.SteamId;
 
         _ = __instance.Reflect().InvokeInternalMethod("SendNewPlayerValuesClientRpc", playerSteamIds);
+
         return false;
     }
 }

--- a/lc-hax/Scripts/Patches/BuildAnywherePatch.cs
+++ b/lc-hax/Scripts/Patches/BuildAnywherePatch.cs
@@ -9,6 +9,7 @@ class BuildAnywherePatch {
     static bool Prefix(ref bool __result, ref bool ___CanConfirmPosition) {
         ___CanConfirmPosition = true;
         __result = !Helper.LocalPlayer.IsNotNull(out PlayerControllerB player) || !player.inTerminalMenu;
+
         return false;
     }
 }

--- a/lc-hax/Scripts/Patches/ConsolePatch.cs
+++ b/lc-hax/Scripts/Patches/ConsolePatch.cs
@@ -8,9 +8,9 @@ class ConsolePatch {
         if (!Helper.HUDManager.IsNotNull(out HUDManager hudManager)) return true;
         if (!hudManager.chatTextField.text.StartsWith("/")) return true;
 
-        Helper.Try(() => Console.ExecuteCommand(hudManager.chatTextField.text), (SystemException exception) => {
-            Logger.Write(exception.ToString());
-        });
+        Helper.Try(() => Console.ExecuteCommand(hudManager.chatTextField.text),
+            (SystemException exception) => Logger.Write(exception.ToString())
+        );
 
         return false;
     }

--- a/lc-hax/Scripts/Patches/InfiniteGrabPatch.cs
+++ b/lc-hax/Scripts/Patches/InfiniteGrabPatch.cs
@@ -6,10 +6,7 @@ using UnityEngine;
 
 [HarmonyPatch(typeof(PlayerControllerB), "SetHoverTipAndCurrentInteractTrigger")]
 class InfiniteGrabPatch {
-    static void Postfix(
-        ref int ___interactableObjectsMask,
-        ref float ___grabDistance
-    ) {
+    static void Postfix(ref int ___interactableObjectsMask, ref float ___grabDistance) {
         ___interactableObjectsMask = LayerMask.GetMask(["Props", "InteractableObject"]);
         ___grabDistance = float.MaxValue;
     }

--- a/lc-hax/Scripts/Patches/InvisiblePatch.cs
+++ b/lc-hax/Scripts/Patches/InvisiblePatch.cs
@@ -1,17 +1,16 @@
-/*using GameNetcodeStuff;
+using GameNetcodeStuff;
 using HarmonyLib;
 using UnityEngine;
 using Hax;
 
 [HarmonyPatch(typeof(PlayerControllerB), "UpdatePlayerPositionServerRpc")]
 class InvisiblePatch {
-    static void Prefix(ref Vector3 pos, ref bool inElevator, ref bool exhausted, ref bool isPlayerGrounded) {
+    static void Prefix(ref Vector3 newPos, ref bool inElevator, ref bool exhausted, ref bool isPlayerGrounded) {
         if (Setting.EnableInvisible) {
-            pos = new Vector3(0, -100, 0);
+            newPos = new Vector3(0, -100, 0);
             inElevator = false;
             exhausted = false;
             isPlayerGrounded = true;
         }
     }
 }
-*/


### PR DESCRIPTION
I should've done this from the start.