### PR TITLE
Lobby ID/Steam ID: Display & Clipboard Copy/Paste

### DIFF
--- a/lc-hax/Scripts/Core/InputListener.cs
+++ b/lc-hax/Scripts/Core/InputListener.cs
@@ -26,6 +26,7 @@ public class InputListener : MonoBehaviour {
     public static event Action? onF3Press;
     public static event Action? onF4Press;
     public static event Action? onF5Press;
+    public static event Action? onF9Press;
 
     (Func<bool>, Action)[] InputActions { get; } = [
         (() => Mouse.current.middleButton.wasPressedThisFrame, () => InputListener.onMiddleButtonPress?.Invoke()),
@@ -47,6 +48,7 @@ public class InputListener : MonoBehaviour {
         (() => Keyboard.current[Key.F3].wasPressedThisFrame, () => InputListener.onF3Press?.Invoke()),
         (() => Keyboard.current[Key.F4].wasPressedThisFrame, () => InputListener.onF4Press?.Invoke()),
         (() => Keyboard.current[Key.F5].wasPressedThisFrame, () => InputListener.onF5Press?.Invoke()),
+        (() => Keyboard.current[Key.F9].wasPressedThisFrame, () => InputListener.onF9Press?.Invoke()),
     ];
 
     void Update() {

--- a/lc-hax/Scripts/Core/InputListener.cs
+++ b/lc-hax/Scripts/Core/InputListener.cs
@@ -19,8 +19,11 @@ public class InputListener : MonoBehaviour {
     public static event Action? onZPress;
     public static event Action? onXPress;
     public static event Action? onNPress;
+    public static event Action? onCPress;
+    public static event Action? onVPress;
     public static event Action? onUpArrowPress;
     public static event Action? onDownArrowPress;
+    public static event Action? onF3Press;
     public static event Action? onF4Press;
     public static event Action? onF5Press;
 
@@ -37,8 +40,11 @@ public class InputListener : MonoBehaviour {
         (() => Keyboard.current[Key.Z].wasPressedThisFrame, () => InputListener.onZPress?.Invoke()),
         (() => Keyboard.current[Key.X].wasPressedThisFrame, () => InputListener.onXPress?.Invoke()),
         (() => Keyboard.current[Key.N].wasPressedThisFrame, () => InputListener.onNPress?.Invoke()),
+        (() => Keyboard.current[Key.C].wasPressedThisFrame, () => InputListener.onCPress?.Invoke()),
+        (() => Keyboard.current[Key.V].wasPressedThisFrame, () => InputListener.onVPress?.Invoke()),
         (() => Keyboard.current[Key.UpArrow].wasPressedThisFrame, () => InputListener.onUpArrowPress?.Invoke()),
         (() => Keyboard.current[Key.DownArrow].wasPressedThisFrame, () => InputListener.onDownArrowPress?.Invoke()),
+        (() => Keyboard.current[Key.F3].wasPressedThisFrame, () => InputListener.onF3Press?.Invoke()),
         (() => Keyboard.current[Key.F4].wasPressedThisFrame, () => InputListener.onF4Press?.Invoke()),
         (() => Keyboard.current[Key.F5].wasPressedThisFrame, () => InputListener.onF5Press?.Invoke()),
     ];

--- a/lc-hax/Scripts/Loader.cs
+++ b/lc-hax/Scripts/Loader.cs
@@ -79,6 +79,7 @@ public class Loader : MonoBehaviour {
         Loader.AddHaxModules<DisconnectMod>();
         Loader.AddHaxModules<ClearVisionMod>();
         Loader.AddHaxModules<InstantInteractMod>();
+        Loader.AddHaxModules<LobbyID>();
     }
 
     public static void Unload() {

--- a/lc-hax/Scripts/Modules/AntiKickMod.cs
+++ b/lc-hax/Scripts/Modules/AntiKickMod.cs
@@ -56,7 +56,9 @@ public sealed class AntiKickMod : MonoBehaviour {
 
     IEnumerator DelayClearChatToFalse() {
         yield return new WaitForSeconds(6.5f);
-        this.ClearChatExecuted = false;
+        if (Helper.LocalPlayer is null) {
+            ClearChatExecuted = false;
+        }
     }
 
     void ToggleAntiKick() {

--- a/lc-hax/Scripts/Modules/AntiKickMod.cs
+++ b/lc-hax/Scripts/Modules/AntiKickMod.cs
@@ -22,7 +22,7 @@ public sealed class AntiKickMod : MonoBehaviour {
 
         if (!DisconnectMod.DisconnectionAttempted && !Setting.DisconnectedVoluntarily && Setting.EnableAntiKick && Setting.ConnectedLobbyId is SteamId lobbyId) {
             GameNetworkManager.Instance.StartClient(lobbyId);
-            ClearChatExecuted = true;
+            this.ClearChatExecuted = true;
         }
         DisconnectMod.DisconnectionAttempted = false;
     }
@@ -39,18 +39,16 @@ public sealed class AntiKickMod : MonoBehaviour {
 
         this.HasAnnouncedGameJoin = true;
 
-        if (!ClearChatExecuted) {
+        if (!this.ClearChatExecuted) {
             Helper.CreateComponent<WaitForBehaviour>().SetPredicate(time => time > 1.0f).Init(() => {
                 Chat.Announce($"{Helper.LocalPlayer?.playerUsername} disconnected.", true);
                 Chat.Print("You are invisible! Do /invis to disable!");
             });
         }
 
-        if (ClearChatExecuted) {
-            ClearChatExecuted = false;
-            Helper.CreateComponent<WaitForBehaviour>().SetPredicate(time => time > 1.0f).Init(() => {
-                Chat.Clear();
-            });
+        if (this.ClearChatExecuted) {
+            this.ClearChatExecuted = false;
+            Helper.CreateComponent<WaitForBehaviour>().SetPredicate(time => time > 1.0f).Init(Chat.Clear);
         }
     }
 

--- a/lc-hax/Scripts/Modules/AntiKickMod.cs
+++ b/lc-hax/Scripts/Modules/AntiKickMod.cs
@@ -22,7 +22,7 @@ public sealed class AntiKickMod : MonoBehaviour {
 
         if (!DisconnectMod.DisconnectionAttempted && !Setting.DisconnectedVoluntarily && Setting.EnableAntiKick && Setting.ConnectedLobbyId is SteamId lobbyId) {
             GameNetworkManager.Instance.StartClient(lobbyId);
-            this.ClearChatExecuted = true;
+            ClearChatExecuted = true;
         }
         DisconnectMod.DisconnectionAttempted = false;
     }
@@ -39,17 +39,17 @@ public sealed class AntiKickMod : MonoBehaviour {
 
         this.HasAnnouncedGameJoin = true;
 
-        Helper.CreateComponent<WaitForBehaviour>().SetPredicate(time => time > 1.0f).Init(() => {
-            Chat.Announce($"{Helper.LocalPlayer?.playerUsername} disconnected.", true);
-            Chat.Print("You are invisible! Do /invis to disable!");
-        });
-
-        if (this.ClearChatExecuted) {
-            this.ClearChatExecuted = false;
+        if (!ClearChatExecuted) {
             Helper.CreateComponent<WaitForBehaviour>().SetPredicate(time => time > 1.0f).Init(() => {
-                for (int i = 0; i < 25; i++) {
-                    Chat.Announce($"", true);
-                }
+                Chat.Announce($"{Helper.LocalPlayer?.playerUsername} disconnected.", true);
+                Chat.Print("You are invisible! Do /invis to disable!");
+            });
+        }
+
+        if (ClearChatExecuted) {
+            ClearChatExecuted = false;
+            Helper.CreateComponent<WaitForBehaviour>().SetPredicate(time => time > 1.0f).Init(() => {
+                Chat.Clear();
             });
         }
     }

--- a/lc-hax/Scripts/Modules/AntiKickMod.cs
+++ b/lc-hax/Scripts/Modules/AntiKickMod.cs
@@ -23,8 +23,8 @@ public sealed class AntiKickMod : MonoBehaviour {
 
         if (!DisconnectMod.DisconnectionAttempted && !Setting.DisconnectedVoluntarily && Setting.EnableAntiKick && Setting.ConnectedLobbyId is SteamId lobbyId) {
             GameNetworkManager.Instance.StartClient(lobbyId);
-            ClearChatExecuted = true;
-            StartCoroutine(DelayClearChatToFalse());
+            this.ClearChatExecuted = true;
+            _ = this.StartCoroutine(this.DelayClearChatToFalse());
         }
         DisconnectMod.DisconnectionAttempted = false;
     }
@@ -41,24 +41,22 @@ public sealed class AntiKickMod : MonoBehaviour {
 
         this.HasAnnouncedGameJoin = true;
 
-        if (!ClearChatExecuted) {
+        if (!this.ClearChatExecuted) {
             Helper.CreateComponent<WaitForBehaviour>().SetPredicate(time => time > 1.0f).Init(() => {
                 Chat.Announce($"{Helper.LocalPlayer?.playerUsername} disconnected.", true);
                 Chat.Print("You are invisible! Do /invis to disable!");
             });
         }
 
-        if (ClearChatExecuted) {
-            ClearChatExecuted = false;
-            Helper.CreateComponent<WaitForBehaviour>().SetPredicate(time => time > 1.0f).Init(() => {
-                Chat.Clear();
-            });
+        if (this.ClearChatExecuted) {
+            this.ClearChatExecuted = false;
+            Helper.CreateComponent<WaitForBehaviour>().SetPredicate(time => time > 1.0f).Init(Chat.Clear);
         }
     }
 
     IEnumerator DelayClearChatToFalse() {
         yield return new WaitForSeconds(6.5f);
-        ClearChatExecuted = false;
+        this.ClearChatExecuted = false;
     }
 
     void ToggleAntiKick() {

--- a/lc-hax/Scripts/Modules/AntiKickMod.cs
+++ b/lc-hax/Scripts/Modules/AntiKickMod.cs
@@ -1,7 +1,6 @@
 using UnityEngine;
 using Hax;
 using Steamworks;
-using System.Collections;
 
 public sealed class AntiKickMod : MonoBehaviour {
     bool HasGameStarted { get; set; } = false;
@@ -24,7 +23,6 @@ public sealed class AntiKickMod : MonoBehaviour {
         if (!DisconnectMod.DisconnectionAttempted && !Setting.DisconnectedVoluntarily && Setting.EnableAntiKick && Setting.ConnectedLobbyId is SteamId lobbyId) {
             GameNetworkManager.Instance.StartClient(lobbyId);
             this.ClearChatExecuted = true;
-            _ = this.StartCoroutine(this.DelayClearChatToFalse());
         }
         DisconnectMod.DisconnectionAttempted = false;
     }
@@ -51,13 +49,6 @@ public sealed class AntiKickMod : MonoBehaviour {
         if (this.ClearChatExecuted) {
             this.ClearChatExecuted = false;
             Helper.CreateComponent<WaitForBehaviour>().SetPredicate(time => time > 1.0f).Init(Chat.Clear);
-        }
-    }
-
-    IEnumerator DelayClearChatToFalse() {
-        yield return new WaitForSeconds(6.5f);
-        if (Helper.LocalPlayer is null) {
-            this.ClearChatExecuted = false;
         }
     }
 

--- a/lc-hax/Scripts/Modules/AntiKickMod.cs
+++ b/lc-hax/Scripts/Modules/AntiKickMod.cs
@@ -20,7 +20,7 @@ public sealed class AntiKickMod : MonoBehaviour {
     void OnGameEnd() {
         this.HasAnnouncedGameJoin = false;
 
-        if (!DisconnectMod.DisconnectionAttempted && !Setting.DisconnectedVoluntarily && Setting.EnableAntiKick && Setting.ConnectedLobbyId is SteamId lobbyId) {
+        if (!Setting.DisconnectedVoluntarily && Setting.EnableAntiKick && Setting.ConnectedLobbyId is SteamId lobbyId) {
             GameNetworkManager.Instance.StartClient(lobbyId);
             this.ClearChatExecuted = true;
         }

--- a/lc-hax/Scripts/Modules/AntiKickMod.cs
+++ b/lc-hax/Scripts/Modules/AntiKickMod.cs
@@ -57,7 +57,7 @@ public sealed class AntiKickMod : MonoBehaviour {
     IEnumerator DelayClearChatToFalse() {
         yield return new WaitForSeconds(6.5f);
         if (Helper.LocalPlayer is null) {
-            ClearChatExecuted = false;
+            this.ClearChatExecuted = false;
         }
     }
 

--- a/lc-hax/Scripts/Modules/AntiKickMod.cs
+++ b/lc-hax/Scripts/Modules/AntiKickMod.cs
@@ -5,7 +5,6 @@ using Steamworks;
 public sealed class AntiKickMod : MonoBehaviour {
     bool HasGameStarted { get; set; } = false;
     bool HasAnnouncedGameJoin { get; set; } = false;
-    bool ClearChatExecuted = false;
 
     void OnEnable() {
         InputListener.onBackslashPress += this.ToggleAntiKick;
@@ -22,9 +21,7 @@ public sealed class AntiKickMod : MonoBehaviour {
 
         if (!Setting.DisconnectedVoluntarily && Setting.EnableAntiKick && Setting.ConnectedLobbyId is SteamId lobbyId) {
             GameNetworkManager.Instance.StartClient(lobbyId);
-            this.ClearChatExecuted = true;
         }
-        DisconnectMod.DisconnectionAttempted = false;
     }
 
     bool FindJoinMessageInHistory() =>
@@ -39,17 +36,10 @@ public sealed class AntiKickMod : MonoBehaviour {
 
         this.HasAnnouncedGameJoin = true;
 
-        if (!this.ClearChatExecuted) {
-            Helper.CreateComponent<WaitForBehaviour>().SetPredicate(time => time > 1.0f).Init(() => {
-                Chat.Announce($"{Helper.LocalPlayer?.playerUsername} disconnected.", true);
-                Chat.Print("You are invisible! Do /invis to disable!");
-            });
-        }
-
-        if (this.ClearChatExecuted) {
-            this.ClearChatExecuted = false;
-            Helper.CreateComponent<WaitForBehaviour>().SetPredicate(time => time > 1.0f).Init(Chat.Clear);
-        }
+        Helper.CreateComponent<WaitForBehaviour>().SetPredicate(time => time > 1.0f).Init(() => {
+            Chat.Clear();
+            Chat.Print("You are invisible! Do /invis to disable!");
+        });
     }
 
     void ToggleAntiKick() {

--- a/lc-hax/Scripts/Modules/AntiKickMod.cs
+++ b/lc-hax/Scripts/Modules/AntiKickMod.cs
@@ -22,7 +22,7 @@ public sealed class AntiKickMod : MonoBehaviour {
 
         if (!DisconnectMod.DisconnectionAttempted && !Setting.DisconnectedVoluntarily && Setting.EnableAntiKick && Setting.ConnectedLobbyId is SteamId lobbyId) {
             GameNetworkManager.Instance.StartClient(lobbyId);
-            ClearChatExecuted = true;
+            this.ClearChatExecuted = true;
         }
         DisconnectMod.DisconnectionAttempted = false;
     }
@@ -44,8 +44,8 @@ public sealed class AntiKickMod : MonoBehaviour {
             Chat.Print("You are invisible! Do /invis to disable!");
         });
 
-        if (ClearChatExecuted) {
-            ClearChatExecuted = false;
+        if (this.ClearChatExecuted) {
+            this.ClearChatExecuted = false;
             Helper.CreateComponent<WaitForBehaviour>().SetPredicate(time => time > 1.0f).Init(() => {
                 for (int i = 0; i < 25; i++) {
                     Chat.Announce($"", true);

--- a/lc-hax/Scripts/Modules/DisconnectMod.cs
+++ b/lc-hax/Scripts/Modules/DisconnectMod.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 
 public sealed class DisconnectMod : MonoBehaviour {
     bool IsShiftHeld { get; set; } = false;
+    public static bool DisconnectionAttempted { get; set; } = false;
 
     void OnEnable() {
         InputListener.onShiftButtonHold += this.HoldShift;
@@ -18,5 +19,6 @@ public sealed class DisconnectMod : MonoBehaviour {
     void TryToDisconnect() {
         if (!this.IsShiftHeld) return;
         GameNetworkManager.Instance.Disconnect();
+        DisconnectionAttempted = true;
     }
 }

--- a/lc-hax/Scripts/Modules/DisconnectMod.cs
+++ b/lc-hax/Scripts/Modules/DisconnectMod.cs
@@ -1,3 +1,4 @@
+using Hax;
 using UnityEngine;
 
 public sealed class DisconnectMod : MonoBehaviour {
@@ -17,6 +18,7 @@ public sealed class DisconnectMod : MonoBehaviour {
 
     void TryToDisconnect() {
         if (!this.IsShiftHeld) return;
+
         GameNetworkManager.Instance.Disconnect();
         Setting.DisconnectedVoluntarily = true;
     }

--- a/lc-hax/Scripts/Modules/DisconnectMod.cs
+++ b/lc-hax/Scripts/Modules/DisconnectMod.cs
@@ -18,6 +18,6 @@ public sealed class DisconnectMod : MonoBehaviour {
     void TryToDisconnect() {
         if (!this.IsShiftHeld) return;
         GameNetworkManager.Instance.Disconnect();
-        DisconnectionAttempted = true;
+        Setting.DisconnectedVoluntarily = true;
     }
 }

--- a/lc-hax/Scripts/Modules/DisconnectMod.cs
+++ b/lc-hax/Scripts/Modules/DisconnectMod.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 
 public sealed class DisconnectMod : MonoBehaviour {
     bool IsShiftHeld { get; set; } = false;
-    public static bool DisconnectionAttempted { get; set; } = false;
 
     void OnEnable() {
         InputListener.onShiftButtonHold += this.HoldShift;

--- a/lc-hax/Scripts/Modules/DisconnectMod.cs
+++ b/lc-hax/Scripts/Modules/DisconnectMod.cs
@@ -1,17 +1,22 @@
 using Hax;
 using UnityEngine;
+using Steamworks;
+using System.Collections;
 
 public sealed class DisconnectMod : MonoBehaviour {
     bool IsShiftHeld { get; set; } = false;
+    bool HasAnnouncedGameJoin { get; set; } = false;
 
     void OnEnable() {
         InputListener.onShiftButtonHold += this.HoldShift;
         InputListener.onF4Press += this.TryToDisconnect;
+        InputListener.onF3Press += this.Rejoin;
     }
 
     void OnDisable() {
         InputListener.onShiftButtonHold -= this.HoldShift;
         InputListener.onF4Press -= this.TryToDisconnect;
+        InputListener.onF3Press -= this.Rejoin;
     }
 
     void HoldShift(bool isHeld) => this.IsShiftHeld = isHeld;
@@ -21,5 +26,20 @@ public sealed class DisconnectMod : MonoBehaviour {
 
         GameNetworkManager.Instance.Disconnect();
         Setting.DisconnectedVoluntarily = true;
+    }
+
+    void Rejoin() {
+        if (!this.IsShiftHeld) return;
+        GameNetworkManager.Instance.Disconnect();
+        Setting.DisconnectedVoluntarily = true;
+        _ = this.StartCoroutine(this.JoinLastGame());
+    }
+
+    IEnumerator JoinLastGame() {
+        yield return new WaitForSeconds(0.2f);
+        this.HasAnnouncedGameJoin = false;
+        if (Setting.ConnectedLobbyId is SteamId lobbyId) {
+            GameNetworkManager.Instance.StartClient(lobbyId);
+        }
     }
 }

--- a/lc-hax/Scripts/Modules/LobbyID.cs
+++ b/lc-hax/Scripts/Modules/LobbyID.cs
@@ -6,29 +6,29 @@ public class LobbyID : MonoBehaviour {
     bool IsShiftHeld { get; set; } = false;
 
     void OnEnable() {
-        InputListener.onShiftButtonHold += HoldShift;
-        InputListener.onCPress += CopyToClipboard;
-        InputListener.onVPress += PasteFromClipboard;
+        InputListener.onShiftButtonHold += this.HoldShift;
+        InputListener.onCPress += this.CopyToClipboard;
+        InputListener.onVPress += this.PasteFromClipboard;
     }
 
     void OnDisable() {
-        InputListener.onShiftButtonHold -= HoldShift;
-        InputListener.onCPress -= CopyToClipboard;
-        InputListener.onVPress -= PasteFromClipboard;
+        InputListener.onShiftButtonHold -= this.HoldShift;
+        InputListener.onCPress -= this.CopyToClipboard;
+        InputListener.onVPress -= this.PasteFromClipboard;
     }
 
-    void HoldShift(bool isHeld) => IsShiftHeld = isHeld;
+    void HoldShift(bool isHeld) => this.IsShiftHeld = isHeld;
 
     void CopyToClipboard() {
-        if (!IsShiftHeld || Setting.ConnectedLobbyId == null) return;
+        if (!this.IsShiftHeld || Setting.ConnectedLobbyId == null) return;
         GUIUtility.systemCopyBuffer = Setting.ConnectedLobbyId.ToString();
     }
 
     void PasteFromClipboard() {
-        if (!IsShiftHeld) return;
+        if (!this.IsShiftHeld) return;
         string clipboardText = GUIUtility.systemCopyBuffer;
         if (ulong.TryParse(clipboardText, out ulong lobbyIdValue)) {
-            SteamId lobbyId = new SteamId { Value = lobbyIdValue };
+            SteamId lobbyId = new() { Value = lobbyIdValue };
             Setting.ConnectedLobbyId = lobbyId;
         }
     }

--- a/lc-hax/Scripts/Modules/LobbyID.cs
+++ b/lc-hax/Scripts/Modules/LobbyID.cs
@@ -4,31 +4,32 @@ using Hax;
 
 public class LobbyID : MonoBehaviour {
     bool IsShiftHeld { get; set; } = false;
+        bool InGame { get; set; } = false;
 
     void OnEnable() {
-        InputListener.onShiftButtonHold += this.HoldShift;
+        InputListener.onShiftButtonHold += HoldShift;
         InputListener.onCPress += this.CopyToClipboard;
         InputListener.onVPress += this.PasteFromClipboard;
     }
 
     void OnDisable() {
-        InputListener.onShiftButtonHold -= this.HoldShift;
+        InputListener.onShiftButtonHold -= HoldShift;
         InputListener.onCPress -= this.CopyToClipboard;
         InputListener.onVPress -= this.PasteFromClipboard;
     }
 
-    void HoldShift(bool isHeld) => this.IsShiftHeld = isHeld;
+    void HoldShift(bool isHeld) => IsShiftHeld = isHeld;
 
     void CopyToClipboard() {
-        if (!this.IsShiftHeld || Setting.ConnectedLobbyId == null) return;
+        if (!IsShiftHeld) return;
         GUIUtility.systemCopyBuffer = Setting.ConnectedLobbyId.ToString();
     }
 
     void PasteFromClipboard() {
-        if (!this.IsShiftHeld) return;
+        if (!IsShiftHeld || Helper.LocalPlayer is not null) return;
         string clipboardText = GUIUtility.systemCopyBuffer;
         if (ulong.TryParse(clipboardText, out ulong lobbyIdValue)) {
-            SteamId lobbyId = new() { Value = lobbyIdValue };
+            SteamId lobbyId = new SteamId { Value = lobbyIdValue };
             Setting.ConnectedLobbyId = lobbyId;
         }
     }

--- a/lc-hax/Scripts/Modules/LobbyID.cs
+++ b/lc-hax/Scripts/Modules/LobbyID.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+using Steamworks;
+using Hax;
+
+public class LobbyID : MonoBehaviour {
+    bool IsShiftHeld { get; set; } = false;
+
+    void OnEnable() {
+        InputListener.onShiftButtonHold += HoldShift;
+        InputListener.onCPress += CopyToClipboard;
+        InputListener.onVPress += PasteFromClipboard;
+    }
+
+    void OnDisable() {
+        InputListener.onShiftButtonHold -= HoldShift;
+        InputListener.onCPress -= CopyToClipboard;
+        InputListener.onVPress -= PasteFromClipboard;
+    }
+
+    void HoldShift(bool isHeld) => IsShiftHeld = isHeld;
+
+    void CopyToClipboard() {
+        if (!IsShiftHeld || Setting.ConnectedLobbyId == null) return;
+        GUIUtility.systemCopyBuffer = Setting.ConnectedLobbyId.ToString();
+    }
+
+    void PasteFromClipboard() {
+        if (!IsShiftHeld) return;
+        string clipboardText = GUIUtility.systemCopyBuffer;
+        if (ulong.TryParse(clipboardText, out ulong lobbyIdValue)) {
+            SteamId lobbyId = new SteamId { Value = lobbyIdValue };
+            Setting.ConnectedLobbyId = lobbyId;
+        }
+    }
+}

--- a/lc-hax/Scripts/Modules/LobbyID.cs
+++ b/lc-hax/Scripts/Modules/LobbyID.cs
@@ -4,32 +4,32 @@ using Hax;
 
 public class LobbyID : MonoBehaviour {
     bool IsShiftHeld { get; set; } = false;
-        bool InGame { get; set; } = false;
+    bool InGame { get; set; } = false;
 
     void OnEnable() {
-        InputListener.onShiftButtonHold += HoldShift;
+        InputListener.onShiftButtonHold += this.HoldShift;
         InputListener.onCPress += this.CopyToClipboard;
         InputListener.onVPress += this.PasteFromClipboard;
     }
 
     void OnDisable() {
-        InputListener.onShiftButtonHold -= HoldShift;
+        InputListener.onShiftButtonHold -= this.HoldShift;
         InputListener.onCPress -= this.CopyToClipboard;
         InputListener.onVPress -= this.PasteFromClipboard;
     }
 
-    void HoldShift(bool isHeld) => IsShiftHeld = isHeld;
+    void HoldShift(bool isHeld) => this.IsShiftHeld = isHeld;
 
     void CopyToClipboard() {
-        if (!IsShiftHeld) return;
+        if (!this.IsShiftHeld) return;
         GUIUtility.systemCopyBuffer = Setting.ConnectedLobbyId.ToString();
     }
 
     void PasteFromClipboard() {
-        if (!IsShiftHeld || Helper.LocalPlayer is not null) return;
+        if (!this.IsShiftHeld || Helper.LocalPlayer is not null) return;
         string clipboardText = GUIUtility.systemCopyBuffer;
         if (ulong.TryParse(clipboardText, out ulong lobbyIdValue)) {
-            SteamId lobbyId = new SteamId { Value = lobbyIdValue };
+            SteamId lobbyId = new() { Value = lobbyIdValue };
             Setting.ConnectedLobbyId = lobbyId;
         }
     }

--- a/lc-hax/Scripts/Modules/MinimalGUIMod.cs
+++ b/lc-hax/Scripts/Modules/MinimalGUIMod.cs
@@ -15,16 +15,25 @@ public class MinimalGUIMod : MonoBehaviour {
     }
 
     void OnGUI() {
-        string labelText = !this.InGame
-            ? $"Lobby Id: {Setting.ConnectedLobbyId}" +
-                $"\nAnti-Kick: {(Setting.EnableAntiKick ? "On" : "Off")}"
-            : $"Lobby Id: {Setting.ConnectedLobbyId}";
         GUIStyle labelStyle = GUI.skin.label;
-        Vector2 labelSize = labelStyle.CalcSize(new GUIContent(labelText));
-        float xPosition = Screen.width - labelSize.x - 10;
-        float yPosition = 0;
-        Rect labelRect = new(xPosition, yPosition, labelSize.x, labelSize.y);
-        GUI.Label(labelRect, labelText);
+        string lobbyIdText = $"Lobby Id: {(Setting.ConnectedLobbyId)}";
+        string antiKickText = $"Anti-Kick: {(Setting.EnableAntiKick ? "On" : "Off")}";
+
+        Vector2 lobbyIdSize = labelStyle.CalcSize(new GUIContent(lobbyIdText));
+        float lobbyIdXPosition = Screen.width - lobbyIdSize.x - 10;
+        float lobbyIdYPosition = 0;
+        Rect lobbyIdRect = new Rect(lobbyIdXPosition, lobbyIdYPosition, lobbyIdSize.x, lobbyIdSize.y);
+
+        Vector2 antiKickSize = labelStyle.CalcSize(new GUIContent(antiKickText));
+        float antiKickXPosition = Screen.width - antiKickSize.x - 10;
+        float antiKickYPosition = lobbyIdYPosition + lobbyIdSize.y;
+        Rect antiKickRect = new Rect(antiKickXPosition, antiKickYPosition, antiKickSize.x, antiKickSize.y);
+
+        GUI.Label(lobbyIdRect, lobbyIdText);
+
+        if (!this.InGame) {
+            GUI.Label(antiKickRect, antiKickText);
+        }
     }
 
     void ToggleInGame() => this.InGame = true;

--- a/lc-hax/Scripts/Modules/MinimalGUIMod.cs
+++ b/lc-hax/Scripts/Modules/MinimalGUIMod.cs
@@ -8,27 +8,27 @@ public class MinimalGUIMod : MonoBehaviour {
     void OnEnable() {
         GameListener.onGameStart += this.ToggleInGame;
         GameListener.onGameEnd += this.ToggleNotInGame;
-        InputListener.onF9Press += LobbyInfo;
+        InputListener.onF9Press += this.LobbyInfo;
     }
 
     void OnDisable() {
         GameListener.onGameStart -= this.ToggleInGame;
         GameListener.onGameEnd -= this.ToggleNotInGame;
-        InputListener.onF9Press -= LobbyInfo;
+        InputListener.onF9Press -= this.LobbyInfo;
     }
 
     void OnGUI() {
         GUIStyle labelStyle = GUI.skin.label;
         string lobbyIdText = "";
 
-        if (ShowLobbyInfo) {
-            lobbyIdText = $"Lobby ID: <color=#0EE600>{(Setting.ConnectedLobbyId)}</color><color=#999999>" +
+        if (this.ShowLobbyInfo) {
+            lobbyIdText = $"Lobby ID: <color=#0EE600>{Setting.ConnectedLobbyId}</color><color=#999999>" +
                     $"\nShift F4: Disconnect" +
                     $"\nShift F3: Disconnect + ReJoin" +
                     $"\nF9: Toggle Lobby Info</color>";
         }
-        if (ShowLobbyInfo && !this.InGame) {
-            lobbyIdText = $"Lobby ID: <color=#0EE600>{(Setting.ConnectedLobbyId)}</color><color=#999999>" +
+        if (this.ShowLobbyInfo && !this.InGame) {
+            lobbyIdText = $"Lobby ID: <color=#0EE600>{Setting.ConnectedLobbyId}</color><color=#999999>" +
                 $"\nShift F3: Join ID" +
                 $"\nShift C: Copy ID" +
                 $"\nShift V: Paste Clipboard To ID" +
@@ -39,12 +39,12 @@ public class MinimalGUIMod : MonoBehaviour {
         Vector2 lobbyIdSize = labelStyle.CalcSize(new GUIContent(lobbyIdText));
         float lobbyIdXPosition = 10f;
         float lobbyIdYPosition = 0;
-        Rect lobbyIdRect = new Rect(lobbyIdXPosition, lobbyIdYPosition, lobbyIdSize.x, lobbyIdSize.y);
+        Rect lobbyIdRect = new(lobbyIdXPosition, lobbyIdYPosition, lobbyIdSize.x, lobbyIdSize.y);
 
         Vector2 antiKickSize = labelStyle.CalcSize(new GUIContent(antiKickText));
         float antiKickXPosition = Screen.width - antiKickSize.x - 10;
         float antiKickYPosition = 0;
-        Rect antiKickRect = new Rect(antiKickXPosition, antiKickYPosition, antiKickSize.x, antiKickSize.y);
+        Rect antiKickRect = new(antiKickXPosition, antiKickYPosition, antiKickSize.x, antiKickSize.y);
 
         GUI.Label(lobbyIdRect, lobbyIdText);
 
@@ -54,7 +54,7 @@ public class MinimalGUIMod : MonoBehaviour {
     }
 
     void LobbyInfo() {
-        ShowLobbyInfo = !ShowLobbyInfo;
+        this.ShowLobbyInfo = !this.ShowLobbyInfo;
     }
 
     void ToggleInGame() => this.InGame = true;

--- a/lc-hax/Scripts/Modules/MinimalGUIMod.cs
+++ b/lc-hax/Scripts/Modules/MinimalGUIMod.cs
@@ -23,15 +23,15 @@ public class MinimalGUIMod : MonoBehaviour {
 
         if (this.ShowLobbyInfo) {
             lobbyIdText = $"Lobby ID: <color=#0EE600>{Setting.ConnectedLobbyId}</color><color=#999999>" +
-                    $"\nShift F4: Disconnect" +
-                    $"\nShift F3: Disconnect + ReJoin" +
+                    $"\nShift+F4: Disconnect" +
+                    $"\nShift+F3: Disconnect + ReJoin" +
                     $"\nF9: Toggle Lobby Info</color>";
         }
         if (this.ShowLobbyInfo && !this.InGame) {
             lobbyIdText = $"Lobby ID: <color=#0EE600>{Setting.ConnectedLobbyId}</color><color=#999999>" +
-                $"\nShift F3: Join ID" +
-                $"\nShift C: Copy ID" +
-                $"\nShift V: Paste Clipboard To ID" +
+                $"\nShift+F3: Join ID" +
+                $"\nShift+C: Copy ID" +
+                $"\nShift+V: Paste Clipboard To ID" +
                 $"\nF9: Toggle Lobby Info</color>";
         }
         string antiKickText = $"Anti-Kick: {(Setting.EnableAntiKick ? "<color=#0EE600>On</color>" : "<color=#E60000>Off</color>")}";

--- a/lc-hax/Scripts/Modules/MinimalGUIMod.cs
+++ b/lc-hax/Scripts/Modules/MinimalGUIMod.cs
@@ -15,14 +15,10 @@ public class MinimalGUIMod : MonoBehaviour {
     }
 
     void OnGUI() {
-        string labelText;
-        if (!this.InGame) {
-            labelText = $"Lobby Id: {(Setting.ConnectedLobbyId)}" +
-                $"\nAnti-Kick: {(Setting.EnableAntiKick ? "On" : "Off")}";
-        }
-        else {
-            labelText = $"Lobby Id: {(Setting.ConnectedLobbyId)}";
-        }
+        string labelText = !this.InGame
+            ? $"Lobby Id: {Setting.ConnectedLobbyId}" +
+                $"\nAnti-Kick: {(Setting.EnableAntiKick ? "On" : "Off")}"
+            : $"Lobby Id: {Setting.ConnectedLobbyId}";
         GUIStyle labelStyle = GUI.skin.label;
         Vector2 labelSize = labelStyle.CalcSize(new GUIContent(labelText));
         float xPosition = Screen.width - labelSize.x - 10;

--- a/lc-hax/Scripts/Modules/MinimalGUIMod.cs
+++ b/lc-hax/Scripts/Modules/MinimalGUIMod.cs
@@ -15,9 +15,14 @@ public class MinimalGUIMod : MonoBehaviour {
     }
 
     void OnGUI() {
-        if (this.InGame) return;
-
-        string labelText = $"Anti-Kick: {(Setting.EnableAntiKick ? "On" : "Off")}";
+        string labelText;
+        if (!this.InGame) {
+            labelText = $"Lobby Id: {(Setting.ConnectedLobbyId)}" +
+                $"\nAnti-Kick: {(Setting.EnableAntiKick ? "On" : "Off")}";
+        }
+        else {
+            labelText = $"Lobby Id: {(Setting.ConnectedLobbyId)}";
+        }
         GUIStyle labelStyle = GUI.skin.label;
         Vector2 labelSize = labelStyle.CalcSize(new GUIContent(labelText));
         float xPosition = Screen.width - labelSize.x - 10;

--- a/lc-hax/Scripts/Modules/MinimalGUIMod.cs
+++ b/lc-hax/Scripts/Modules/MinimalGUIMod.cs
@@ -16,18 +16,18 @@ public class MinimalGUIMod : MonoBehaviour {
 
     void OnGUI() {
         GUIStyle labelStyle = GUI.skin.label;
-        string lobbyIdText = $"Lobby Id: {(Setting.ConnectedLobbyId)}";
+        string lobbyIdText = $"Lobby Id: {Setting.ConnectedLobbyId}";
         string antiKickText = $"Anti-Kick: {(Setting.EnableAntiKick ? "On" : "Off")}";
 
         Vector2 lobbyIdSize = labelStyle.CalcSize(new GUIContent(lobbyIdText));
         float lobbyIdXPosition = Screen.width - lobbyIdSize.x - 10;
         float lobbyIdYPosition = 0;
-        Rect lobbyIdRect = new Rect(lobbyIdXPosition, lobbyIdYPosition, lobbyIdSize.x, lobbyIdSize.y);
+        Rect lobbyIdRect = new(lobbyIdXPosition, lobbyIdYPosition, lobbyIdSize.x, lobbyIdSize.y);
 
         Vector2 antiKickSize = labelStyle.CalcSize(new GUIContent(antiKickText));
         float antiKickXPosition = Screen.width - antiKickSize.x - 10;
         float antiKickYPosition = lobbyIdYPosition + lobbyIdSize.y;
-        Rect antiKickRect = new Rect(antiKickXPosition, antiKickYPosition, antiKickSize.x, antiKickSize.y);
+        Rect antiKickRect = new(antiKickXPosition, antiKickYPosition, antiKickSize.x, antiKickSize.y);
 
         GUI.Label(lobbyIdRect, lobbyIdText);
 

--- a/lc-hax/Scripts/Modules/MinimalGUIMod.cs
+++ b/lc-hax/Scripts/Modules/MinimalGUIMod.cs
@@ -3,37 +3,58 @@ using Hax;
 
 public class MinimalGUIMod : MonoBehaviour {
     bool InGame { get; set; } = false;
+    bool ShowLobbyInfo { get; set; } = true;
 
     void OnEnable() {
         GameListener.onGameStart += this.ToggleInGame;
         GameListener.onGameEnd += this.ToggleNotInGame;
+        InputListener.onF9Press += LobbyInfo;
     }
 
     void OnDisable() {
         GameListener.onGameStart -= this.ToggleInGame;
         GameListener.onGameEnd -= this.ToggleNotInGame;
+        InputListener.onF9Press -= LobbyInfo;
     }
 
     void OnGUI() {
         GUIStyle labelStyle = GUI.skin.label;
-        string lobbyIdText = $"Lobby Id: {Setting.ConnectedLobbyId}";
-        string antiKickText = $"Anti-Kick: {(Setting.EnableAntiKick ? "On" : "Off")}";
+        string lobbyIdText = "";
+
+        if (ShowLobbyInfo) {
+            lobbyIdText = $"Lobby ID: <color=#0EE600>{(Setting.ConnectedLobbyId)}</color><color=#999999>" +
+                    $"\nShift F4: Disconnect" +
+                    $"\nShift F3: Disconnect + ReJoin" +
+                    $"\nF9: Toggle Lobby Info</color>";
+        }
+        if (ShowLobbyInfo && !this.InGame) {
+            lobbyIdText = $"Lobby ID: <color=#0EE600>{(Setting.ConnectedLobbyId)}</color><color=#999999>" +
+                $"\nShift F3: Join ID" +
+                $"\nShift C: Copy ID" +
+                $"\nShift V: Paste Clipboard To ID" +
+                $"\nF9: Toggle Lobby Info</color>";
+        }
+        string antiKickText = $"Anti-Kick: {(Setting.EnableAntiKick ? "<color=#0EE600>On</color>" : "<color=#E60000>Off</color>")}";
 
         Vector2 lobbyIdSize = labelStyle.CalcSize(new GUIContent(lobbyIdText));
-        float lobbyIdXPosition = Screen.width - lobbyIdSize.x - 10;
+        float lobbyIdXPosition = 10f;
         float lobbyIdYPosition = 0;
-        Rect lobbyIdRect = new(lobbyIdXPosition, lobbyIdYPosition, lobbyIdSize.x, lobbyIdSize.y);
+        Rect lobbyIdRect = new Rect(lobbyIdXPosition, lobbyIdYPosition, lobbyIdSize.x, lobbyIdSize.y);
 
         Vector2 antiKickSize = labelStyle.CalcSize(new GUIContent(antiKickText));
         float antiKickXPosition = Screen.width - antiKickSize.x - 10;
-        float antiKickYPosition = lobbyIdYPosition + lobbyIdSize.y;
-        Rect antiKickRect = new(antiKickXPosition, antiKickYPosition, antiKickSize.x, antiKickSize.y);
+        float antiKickYPosition = 0;
+        Rect antiKickRect = new Rect(antiKickXPosition, antiKickYPosition, antiKickSize.x, antiKickSize.y);
 
         GUI.Label(lobbyIdRect, lobbyIdText);
 
         if (!this.InGame) {
             GUI.Label(antiKickRect, antiKickText);
         }
+    }
+
+    void LobbyInfo() {
+        ShowLobbyInfo = !ShowLobbyInfo;
     }
 
     void ToggleInGame() => this.InGame = true;


### PR DESCRIPTION
### Lobby ID/Steam ID: Display & Clipboard Copy/Paste
Added a few changes evolving around Lobby ID, the biggest changes is the fact that you can copy and paste into the current Lobby ID, this is very useful because the lobby ID is actually the host Steam ID no matter what, so if you have someones Steam ID by copying it or just having it, you can forcefully join their game even if it's private.


### Changes
- Made it where the current/last Lobby ID is displayed in the top right, note the lobby ID is actually the host steam ID.
- Made it where you can copy the current Lobby ID with `Shift + C`
- Made it where you can paste from your clipboard into the current Lobby ID with `Shift + V`